### PR TITLE
Load Styrene A and Tiempos Text webfonts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,9 @@
+@import url('https://fonts.cdnfonts.com/css/styrene-a');
+@import url('https://fonts.cdnfonts.com/css/tiempos-text');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 
 /* Custom font fallbacks */
 .font-title {


### PR DESCRIPTION
## Summary
- import the Styrene A and Tiempos Text font families from the CDN within the global stylesheet
- ensure the `font-title` and `font-body` utility classes keep pointing at the new font-family stack so Tailwind components pick up the brand typography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d19519bcb483318544af971d1773c4