### PR TITLE
Type features state as string array

### DIFF
--- a/src/components/ProjectQuote.tsx
+++ b/src/components/ProjectQuote.tsx
@@ -3,7 +3,20 @@ import { Send, CheckCircle, Clock, DollarSign } from 'lucide-react';
 
 const ProjectQuote = () => {
   const [step, setStep] = useState(1);
-  const [formData, setFormData] = useState({
+  interface QuoteFormData {
+    projectType: string;
+    budget: string;
+    timeline: string;
+    name: string;
+    email: string;
+    company: string;
+    phone: string;
+    description: string;
+    features: string[];
+    priority: 'low' | 'medium' | 'high';
+  }
+
+  const [formData, setFormData] = useState<QuoteFormData>({
     projectType: '',
     budget: '',
     timeline: '',


### PR DESCRIPTION
## Summary
- add a dedicated QuoteFormData interface so the ProjectQuote form state is explicitly typed
- annotate the features field as a string array while keeping other properties typed for future updates

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d20c25fc088331a803bcd9416d8fad