### PR TITLE
Adjust layout styling for header hero footer

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -47,7 +47,7 @@ function App() {
   return (
     <div className="min-h-screen bg-white">
       <Header currentPage={currentPage} setCurrentPage={setCurrentPage} />
-      <main>
+      <main className="pt-16">
         {renderPage()}
       </main>
       <Footer currentPage={currentPage} setCurrentPage={setCurrentPage} />

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -31,113 +31,126 @@ const Footer: React.FC<FooterProps> = ({ setCurrentPage }) => {
   };
 
   return (
-    <footer className="bg-dim-gray text-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="grid lg:grid-cols-5 gap-8">
-          {/* Company Info */}
-          <div className="lg:col-span-2 space-y-6">
-            <div>
-              <button
-                onClick={() => setCurrentPage('home')}
-                className="text-2xl font-bold text-white hover:text-red-ncs transition-colors"
-              >
-                The Run Sun
-              </button>
-              <p className="text-white/70 mt-4 leading-relaxed">
-                Leading IT solutions company in Sri Lanka, committed to transforming businesses 
-                through innovative technology, ethical practices, and sustainable development.
-              </p>
-            </div>
+    <footer className="bg-black text-black">
+      <div className="w-full px-4 sm:px-6 lg:px-10 py-14">
+        <div className="max-w-screen-2xl mx-auto">
+          <div className="rounded-[2.5rem] border border-black/20 bg-white p-10 sm:p-12">
+            <div className="grid gap-10 lg:grid-cols-5">
+              {/* Company Info */}
+              <div className="lg:col-span-2 space-y-6">
+                <div>
+                  <button
+                    onClick={() => setCurrentPage('home')}
+                    className="text-2xl font-bold text-black transition-opacity hover:opacity-80"
+                  >
+                    The Run Sun
+                  </button>
+                  <p className="mt-4 leading-relaxed text-black">
+                    Leading IT solutions company in Sri Lanka, committed to transforming businesses
+                    through innovative technology, ethical practices, and sustainable development.
+                  </p>
+                </div>
 
-            <div className="space-y-3">
-              <div className="flex items-center space-x-3">
-                <MapPin className="w-5 h-5 text-red-ncs" />
-                <span className="text-white/80">123 Galle Road, Colombo 03, Sri Lanka</span>
+                <div className="space-y-3 text-black">
+                  <div className="flex items-center space-x-3">
+                    <MapPin className="w-5 h-5 text-black" />
+                    <span>123 Galle Road, Colombo 03, Sri Lanka</span>
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <Phone className="w-5 h-5 text-black" />
+                    <span>+94 11 234 5678</span>
+                  </div>
+                  <div className="flex items-center space-x-3">
+                    <Mail className="w-5 h-5 text-black" />
+                    <span>info@therunsun.lk</span>
+                  </div>
+                </div>
+
+                <div className="flex space-x-4">
+                  <a
+                    href="#"
+                    className="w-11 h-11 rounded-full border border-black flex items-center justify-center bg-orange-100 transition-colors hover:bg-orange-200"
+                  >
+                    <Facebook className="w-5 h-5" />
+                  </a>
+                  <a
+                    href="#"
+                    className="w-11 h-11 rounded-full border border-black flex items-center justify-center bg-orange-100 transition-colors hover:bg-orange-200"
+                  >
+                    <Twitter className="w-5 h-5" />
+                  </a>
+                  <a
+                    href="#"
+                    className="w-11 h-11 rounded-full border border-black flex items-center justify-center bg-orange-100 transition-colors hover:bg-orange-200"
+                  >
+                    <Linkedin className="w-5 h-5" />
+                  </a>
+                </div>
               </div>
-              <div className="flex items-center space-x-3">
-                <Phone className="w-5 h-5 text-red-ncs" />
-                <span className="text-white/80">+94 11 234 5678</span>
+
+              {/* Navigation Links */}
+              <div className="grid gap-10 md:grid-cols-3 lg:col-span-3">
+                <div>
+                  <h3 className="text-lg font-semibold mb-4 text-black">Company</h3>
+                  <ul className="space-y-2">
+                    {navigation.company.map((item) => (
+                      <li key={item.name}>
+                        <button
+                          onClick={() => setCurrentPage(item.id)}
+                          className="list-item transition-opacity hover:opacity-80"
+                        >
+                          {item.name}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="text-lg font-semibold mb-4 text-black">Services</h3>
+                  <ul className="space-y-2 text-black">
+                    {navigation.services.map((item) => (
+                      <li key={item.name}>
+                        <button
+                          onClick={() => setCurrentPage(item.id)}
+                          className="text-black transition-opacity hover:opacity-80"
+                        >
+                          {item.name}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="text-lg font-semibold mb-4 text-black">Resources</h3>
+                  <ul className="space-y-2 text-black">
+                    {navigation.resources.map((item) => (
+                      <li key={item.name}>
+                        <button
+                          onClick={() => setCurrentPage(item.id)}
+                          className="text-black transition-opacity hover:opacity-80"
+                        >
+                          {item.name}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
               </div>
-              <div className="flex items-center space-x-3">
-                <Mail className="w-5 h-5 text-red-ncs" />
-                <span className="text-white/80">info@therunsun.lk</span>
+            </div>
+
+            <div className="mt-12 border-t border-black/10 pt-8">
+              <div className="flex flex-col gap-4 text-black md:flex-row md:items-center md:justify-between">
+                <p className="text-sm text-black">
+                  © 2024 The Run Sun (Pvt) Ltd. All rights reserved.
+                </p>
+                <div className="flex space-x-6 text-sm text-black">
+                  <a href="#" className="transition-opacity hover:opacity-80">Privacy Policy</a>
+                  <a href="#" className="transition-opacity hover:opacity-80">Terms of Service</a>
+                  <a href="#" className="transition-opacity hover:opacity-80">Cookie Policy</a>
+                </div>
               </div>
-            </div>
-
-            <div className="flex space-x-4">
-              <a href="#" className="w-10 h-10 bg-white/10 rounded-full flex items-center justify-center hover:bg-red-ncs transition-colors">
-                <Facebook className="w-5 h-5" />
-              </a>
-              <a href="#" className="w-10 h-10 bg-white/10 rounded-full flex items-center justify-center hover:bg-red-ncs transition-colors">
-                <Twitter className="w-5 h-5" />
-              </a>
-              <a href="#" className="w-10 h-10 bg-white/10 rounded-full flex items-center justify-center hover:bg-red-ncs transition-colors">
-                <Linkedin className="w-5 h-5" />
-              </a>
-            </div>
-          </div>
-
-          {/* Navigation Links */}
-          <div className="grid md:grid-cols-3 lg:grid-cols-3 gap-8 lg:col-span-3">
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Company</h3>
-              <ul className="space-y-2">
-                {navigation.company.map((item) => (
-                  <li key={item.name}>
-                    <button
-                      onClick={() => setCurrentPage(item.id)}
-                      className="list-item hover:text-white transition-colors"
-                    >
-                      {item.name}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Services</h3>
-              <ul className="space-y-2">
-                {navigation.services.map((item) => (
-                  <li key={item.name}>
-                    <button
-                      onClick={() => setCurrentPage(item.id)}
-                      className="text-white/70 hover:text-white transition-colors"
-                    >
-                      {item.name}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-
-            <div>
-              <h3 className="text-lg font-semibold mb-4">Resources</h3>
-              <ul className="space-y-2">
-                {navigation.resources.map((item) => (
-                  <li key={item.name}>
-                    <button
-                      onClick={() => setCurrentPage(item.id)}
-                      className="text-white/70 hover:text-white transition-colors"
-                    >
-                      {item.name}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
-        </div>
-
-        <div className="border-t border-white/10 mt-12 pt-8">
-          <div className="flex flex-col md:flex-row justify-between items-center space-y-4 md:space-y-0">
-            <p className="text-white/60 text-sm">
-              © 2024 The Run Sun (Pvt) Ltd. All rights reserved.
-            </p>
-            <div className="flex space-x-6 text-sm">
-              <a href="#" className="text-white/60 hover:text-white transition-colors">Privacy Policy</a>
-              <a href="#" className="text-white/60 hover:text-white transition-colors">Terms of Service</a>
-              <a href="#" className="text-white/60 hover:text-white transition-colors">Cookie Policy</a>
             </div>
           </div>
         </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,84 +19,84 @@ const Header: React.FC<HeaderProps> = ({ currentPage, setCurrentPage }) => {
 		{ name: 'Contact', id: 'contact' },
 	];
 
-	return (
-		<header className="fixed top-0 left-0 right-0 z-50 bg-white/80 backdrop-blur-lg border-b border-gray-100">
-			<div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
-				<div className="flex justify-between items-center h-16">
-					<div className="flex items-center">
-						<button
-							onClick={() => setCurrentPage('home')}
-							className="text-2xl font-title font-bold text-red-ncs hover:opacity-80 transition-opacity"
-						>
-							The Run Sun
-						</button>
-					</div>
+        return (
+                <header className="fixed top-0 left-0 right-0 z-50 bg-orange-100 border-b border-orange-200">
+                        <div className="w-full px-4 sm:px-6 lg:px-10">
+                                <div className="flex justify-between items-center h-16">
+                                        <div className="flex items-center">
+                                                <button
+                                                        onClick={() => setCurrentPage('home')}
+                                                        className="text-2xl font-title font-bold text-black transition-opacity hover:opacity-80"
+                                                >
+                                                        The Run Sun
+                                                </button>
+                                        </div>
 
-					{/* Desktop Navigation */}
-					<nav className="hidden lg:flex items-center space-x-8">
-						{navigation.map((item) => (
-							<button
-								key={item.id}
-								onClick={() => setCurrentPage(item.id)}
-								className={`menu-item font-medium transition-colors ${currentPage === item.id
-										? 'text-red-ncs'
-										: 'text-dim-gray hover:text-red-ncs'
-									}`}
-							>
-								{item.name}
-							</button>
-						))}
-						<button
-							onClick={() => setCurrentPage('quote')}
-							className="bg-red-ncs text-white px-6 py-2 rounded-full hover:bg-red-ncs/90 transition-colors"
-						>
-							Get Quote
-						</button>
-					</nav>
+                                        {/* Desktop Navigation */}
+                                        <nav className="hidden lg:flex items-center space-x-8">
+                                                {navigation.map((item) => (
+                                                        <button
+                                                                key={item.id}
+                                                                onClick={() => setCurrentPage(item.id)}
+                                                                className={`menu-item font-medium transition-opacity ${currentPage === item.id
+                                                                                ? 'opacity-100'
+                                                                                : 'opacity-70 hover:opacity-100'
+                                                                        }`}
+                                                        >
+                                                                {item.name}
+                                                        </button>
+                                                ))}
+                                                <button
+                                                        onClick={() => setCurrentPage('quote')}
+                                                        className="px-6 py-2 rounded-full bg-white text-black border border-black transition-colors hover:bg-orange-200"
+                                                >
+                                                        Get Quote
+                                                </button>
+                                        </nav>
 
-					{/* Mobile menu button */}
-					<button
-						onClick={() => setIsMenuOpen(!isMenuOpen)}
-						className="lg:hidden p-2 text-dim-gray hover:text-red-ncs"
-					>
-						{isMenuOpen ? <X size={24} /> : <Menu size={24} />}
-					</button>
-				</div>
+                                        {/* Mobile menu button */}
+                                        <button
+                                                onClick={() => setIsMenuOpen(!isMenuOpen)}
+                                                className="lg:hidden p-2 text-black hover:opacity-80"
+                                        >
+                                                {isMenuOpen ? <X size={24} /> : <Menu size={24} />}
+                                        </button>
+                                </div>
 
-				{/* Mobile Navigation */}
-				{isMenuOpen && (
-					<div className="lg:hidden absolute top-16 left-0 right-0 bg-white border-b border-gray-100 shadow-lg">
-						<nav className="px-4 py-4 space-y-2">
-							{navigation.map((item) => (
-								<button
-									key={item.id}
-									onClick={() => {
-										setCurrentPage(item.id);
-										setIsMenuOpen(false);
-									}}
-									className={`block w-full text-left px-4 py-2 rounded-lg menu-item transition-colors ${currentPage === item.id
-											? 'text-red-ncs bg-light-green/20'
-											: 'text-dim-gray hover:text-red-ncs hover:bg-gray-50'
-										}`}
-								>
-									{item.name}
-								</button>
-							))}
-							<button
-								onClick={() => {
-									setCurrentPage('quote');
-									setIsMenuOpen(false);
-								}}
-								className="block w-full text-left px-4 py-2 bg-red-ncs text-white rounded-lg hover:bg-red-ncs/90 transition-colors mt-4"
-							>
-								Get Quote
-							</button>
-						</nav>
-					</div>
-				)}
-			</div>
-		</header>
-	);
+                                {/* Mobile Navigation */}
+                                {isMenuOpen && (
+                                        <div className="lg:hidden absolute top-16 left-0 right-0 bg-orange-100 border-b border-orange-200 shadow-lg">
+                                                <nav className="px-4 py-4 space-y-2">
+                                                        {navigation.map((item) => (
+                                                                <button
+                                                                        key={item.id}
+                                                                        onClick={() => {
+                                                                                setCurrentPage(item.id);
+                                                                                setIsMenuOpen(false);
+                                                                        }}
+                                                                        className={`block w-full text-left px-4 py-2 rounded-lg menu-item transition-opacity ${currentPage === item.id
+                                                                                        ? 'opacity-100 bg-white'
+                                                                                        : 'opacity-70 hover:opacity-100 hover:bg-white/70'
+                                                                                }`}
+                                                                >
+                                                                        {item.name}
+                                                                </button>
+                                                        ))}
+                                                        <button
+                                                                onClick={() => {
+                                                                        setCurrentPage('quote');
+                                                                        setIsMenuOpen(false);
+                                                                }}
+                                                                className="block w-full text-left px-4 py-2 rounded-lg bg-white text-black border border-black transition-colors mt-4 hover:bg-orange-200"
+                                                        >
+                                                                Get Quote
+                                                        </button>
+                                                </nav>
+                                        </div>
+                                )}
+                        </div>
+                </header>
+        );
 };
 
 export default Header;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,24 +1,42 @@
 import React, { useState, useEffect } from 'react';
-import { ChevronLeft, ChevronRight, Play } from 'lucide-react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 const Hero = () => {
   const [currentSlide, setCurrentSlide] = useState(0);
 
   const slides = [
     {
-      title: "AI research and products that put safety at the frontier",
-      subtitle: "Transforming businesses through cutting-edge technology",
-      description: "We deliver comprehensive IT services and products that drive digital transformation and accelerate business growth.",
+      title: 'AI research and products that put safety at the frontier',
+      subtitle: 'Transforming businesses through cutting-edge technology',
+      description:
+        'We deliver comprehensive IT services and products that drive digital transformation and accelerate business growth.',
     },
     {
-      title: "AI research and products that put safety at the frontier",
-      subtitle: "Building a greener digital future",
-      description: "Our commitment to sustainability drives us to create eco-friendly solutions that benefit both business and environment.",
+      title: 'AI research and products that put safety at the frontier',
+      subtitle: 'Building a greener digital future',
+      description:
+        'Our commitment to sustainability drives us to create eco-friendly solutions that benefit both business and environment.',
     },
     {
-      title: "AI research and products that put safety at the frontier",
-      subtitle: "Responsible artificial intelligence for all",
-      description: "We develop AI solutions with ethics at the core, ensuring fairness, transparency, and positive impact on society.",
+      title: 'AI research and products that put safety at the frontier',
+      subtitle: 'Responsible artificial intelligence for all',
+      description:
+        'We develop AI solutions with ethics at the core, ensuring fairness, transparency, and positive impact on society.',
+    },
+  ];
+
+  const columnHighlights = [
+    {
+      heading: 'Strategic technology leadership',
+      body:
+        'Partner with a team that aligns advanced engineering with clear business outcomes for measurable growth.',
+      bullets: ['Modern platform architecture', 'Value-focused delivery roadmaps', 'Embedded knowledge transfer'],
+    },
+    {
+      heading: 'Responsible innovation at scale',
+      body:
+        'Confidently adopt AI and cloud capabilities with frameworks that keep people, planet, and governance at the center.',
+      bullets: ['Ethical AI implementation', 'Sustainability-first solutions', '24/7 strategic guidance'],
     },
   ];
 
@@ -30,97 +48,81 @@ const Hero = () => {
   }, []);
 
   return (
-    <section className="relative min-h-screen flex items-center overflow-hidden">
-      {/* Animated Background - Placeholder for Three.js/Spline */}
-      <div className="absolute inset-0">
-        <div className="absolute inset-0 bg-gradient-to-br from-light-green/20 via-olivine/10 to-peach/20"></div>
-        <div className="absolute inset-0 opacity-30">
-          {[...Array(20)].map((_, i) => (
-            <div
-              key={i}
-              className="absolute rounded-full bg-gradient-to-r from-red-ncs/20 to-olivine/20 animate-pulse"
-              style={{
-                width: Math.random() * 200 + 50,
-                height: Math.random() * 200 + 50,
-                left: Math.random() * 100 + '%',
-                top: Math.random() * 100 + '%',
-                animationDelay: Math.random() * 5 + 's',
-                animationDuration: (Math.random() * 10 + 10) + 's',
-              }}
-            />
-          ))}
-        </div>
-      </div>
-
-  <div className="relative z-10 max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 w-full">
-        <div className="grid lg:grid-cols-2 gap-12 items-center min-h-screen py-20">
-          {/* Content Slider */}
-          <div className="space-y-8">
-            <div className="space-y-6">
-              <h1 className="text-5xl lg:text-7xl font-title font-bold text-black leading-tight">
-                {slides[currentSlide].title}
-              </h1>
-              <h2 className="text-2xl lg:text-3xl font-title text-red-ncs font-light">
-                {slides[currentSlide].subtitle}
-              </h2>
-              <p className="text-lg font-body text-dim-gray/80 leading-relaxed max-w-lg">
-                {slides[currentSlide].description}
-              </p>
-            </div>
-
-            <div className="flex items-center space-x-6">
-              <button className="bg-red-ncs text-white px-8 py-4 rounded-full hover:bg-red-ncs/90 transition-all duration-300 transform hover:scale-105">
-                Explore Solutions
-              </button>
-              <button className="flex items-center space-x-2 font-body text-dim-gray hover:text-red-ncs transition-colors group">
-                <div className="w-12 h-12 border-2 border-current rounded-full flex items-center justify-center group-hover:border-red-ncs">
-                  <Play size={16} className="ml-1" />
+    <section className="relative bg-orange-50 pt-28 pb-16 min-h-[60vh]">
+      <div className="relative z-10 w-full px-4 sm:px-6 lg:px-10">
+        <div className="max-w-screen-2xl mx-auto">
+          <div className="bg-white border border-orange-100 rounded-[2.5rem] shadow-xl">
+            <div className="grid gap-10 lg:grid-cols-3 p-10 lg:p-14">
+              <div className="space-y-6 lg:pr-10">
+                <div className="space-y-4">
+                  <p className="uppercase tracking-[0.35em] text-xs font-semibold text-black">{slides[currentSlide].subtitle}</p>
+                  <h1 className="text-4xl lg:text-5xl font-title font-bold text-black leading-tight">
+                    {slides[currentSlide].title}
+                  </h1>
+                  <p className="text-lg font-body text-black leading-relaxed">
+                    {slides[currentSlide].description}
+                  </p>
                 </div>
-                <span className="font-title font-medium">Watch Demo</span>
-              </button>
+                <div className="flex flex-wrap gap-3">
+                  <button className="px-6 py-3 rounded-full border border-black bg-orange-100 text-black font-medium transition-colors hover:bg-orange-200">
+                    Explore solutions
+                  </button>
+                  <button className="px-6 py-3 rounded-full border border-black text-black font-medium transition-colors hover:bg-orange-200">
+                    Talk to our team
+                  </button>
+                </div>
+              </div>
+
+              {columnHighlights.map((highlight, index) => (
+                <div key={highlight.heading} className="flex flex-col justify-between rounded-3xl border border-orange-100 p-6 bg-orange-50">
+                  <div className="space-y-4">
+                    <h3 className="text-xl font-title font-semibold text-black">{highlight.heading}</h3>
+                    <p className="text-base font-body text-black leading-relaxed">{highlight.body}</p>
+                    <ul className="space-y-2">
+                      {highlight.bullets.map((item) => (
+                        <li key={item} className="flex items-start gap-2 text-base text-black">
+                          <span className="mt-1 h-1.5 w-1.5 rounded-full bg-black" aria-hidden="true"></span>
+                          <span>{item}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                  <div className="mt-6 text-sm font-medium text-black">{`0${index + 1}`}</div>
+                </div>
+              ))}
             </div>
 
-            {/* Slide Controls */}
-            <div className="flex items-center space-x-4">
-              <button
-                onClick={() => setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length)}
-                className="p-2 rounded-full border border-dim-gray/20 hover:border-red-ncs hover:text-red-ncs transition-colors"
-              >
-                <ChevronLeft size={20} />
-              </button>
-              
-              <div className="flex space-x-2">
+            <div className="flex flex-col gap-4 border-t border-orange-100 px-10 py-6 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-center gap-2">
                 {slides.map((_, index) => (
                   <button
                     key={index}
                     onClick={() => setCurrentSlide(index)}
-                    className={`w-3 h-3 rounded-full transition-colors ${
-                      index === currentSlide ? 'bg-red-ncs' : 'bg-dim-gray/20'
+                    className={`h-2 rounded-full transition-all ${
+                      index === currentSlide ? 'w-10 bg-black' : 'w-3 bg-black/50'
                     }`}
+                    aria-label={`Go to slide ${index + 1}`}
                   />
                 ))}
               </div>
 
-              <button
-                onClick={() => setCurrentSlide((prev) => (prev + 1) % slides.length)}
-                className="p-2 rounded-full border border-dim-gray/20 hover:border-red-ncs hover:text-red-ncs transition-colors"
-              >
-                <ChevronRight size={20} />
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={() => setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length)}
+                  className="flex h-11 w-11 items-center justify-center rounded-full border border-black text-black transition-colors hover:bg-orange-200"
+                  aria-label="Previous slide"
+                >
+                  <ChevronLeft size={20} />
+                </button>
+                <button
+                  onClick={() => setCurrentSlide((prev) => (prev + 1) % slides.length)}
+                  className="flex h-11 w-11 items-center justify-center rounded-full border border-black text-black transition-colors hover:bg-orange-200"
+                  aria-label="Next slide"
+                >
+                  <ChevronRight size={20} />
+                </button>
+              </div>
             </div>
-          </div>
-
-          {/* Visual Element */}
-          <div className="relative">
-            <div className="aspect-square bg-gradient-to-br from-light-green via-olivine to-peach rounded-3xl transform rotate-3 hover:rotate-6 transition-transform duration-500">
-              <img
-                src="https://images.pexels.com/photos/3862132/pexels-photo-3862132.jpeg?auto=compress&cs=tinysrgb&w=800"
-                alt="Modern technology"
-                className="w-full h-full object-cover rounded-3xl"
-              />
-            </div>
-            <div className="absolute -bottom-6 -left-6 w-24 h-24 bg-peach rounded-full opacity-80 animate-bounce"></div>
-            <div className="absolute -top-6 -right-6 w-16 h-16 bg-light-green rounded-full opacity-80 animate-pulse"></div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- restyle the fixed header with a full-width orange background, black typography, and updated desktop/mobile call-to-action buttons
- rebuild the hero into a smaller three-column rounded layout with black text, reusable highlights, and refreshed slider controls
- rework the footer into a black-background section with a white content card, black text styling, and consistent navigation and social links
- add top padding to the main content to clear the fixed header height

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2ce80086c833188ecbc796ba1d514