### PR TITLE
Reposition hero slider layout

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -50,29 +50,70 @@ const Hero = () => {
   return (
     <section className="relative bg-orange-50 pt-28 pb-16 min-h-[60vh]">
       <div className="relative z-10 w-full px-4 sm:px-6 lg:px-10">
-        <div className="max-w-screen-2xl mx-auto">
-          <div className="bg-white border border-orange-100 rounded-[2.5rem] shadow-xl">
-            <div className="grid gap-10 lg:grid-cols-3 p-10 lg:p-14">
-              <div className="space-y-6 lg:pr-10">
-                <div className="space-y-4">
-                  <p className="uppercase tracking-[0.35em] text-xs font-semibold text-black">{slides[currentSlide].subtitle}</p>
-                  <h1 className="text-4xl lg:text-5xl font-title font-bold text-black leading-tight">
-                    {slides[currentSlide].title}
-                  </h1>
-                  <p className="text-lg font-body text-black leading-relaxed">
-                    {slides[currentSlide].description}
-                  </p>
+        <div className="max-w-screen-2xl mx-auto space-y-10">
+          <div className="grid gap-10 lg:grid-cols-12 lg:items-center">
+            <div className="space-y-6 lg:col-span-8 lg:pr-10">
+              <div className="space-y-4">
+                <p className="uppercase tracking-[0.35em] text-xs font-semibold text-black">{slides[currentSlide].subtitle}</p>
+                <h1 className="text-4xl lg:text-5xl font-title font-bold text-black leading-tight">
+                  {slides[currentSlide].title}
+                </h1>
+                <p className="text-lg font-body text-black leading-relaxed">{slides[currentSlide].description}</p>
+              </div>
+              <div className="flex flex-wrap gap-3">
+                <button className="px-6 py-3 rounded-full border border-black bg-orange-100 text-black font-medium transition-colors hover:bg-orange-200">
+                  Explore solutions
+                </button>
+                <button className="px-6 py-3 rounded-full border border-black text-black font-medium transition-colors hover:bg-orange-200">
+                  Talk to our team
+                </button>
+              </div>
+              <div className="flex flex-col gap-4 pt-2 lg:flex-row lg:items-center lg:justify-between">
+                <div className="flex items-center gap-2">
+                  {slides.map((_, index) => (
+                    <button
+                      key={index}
+                      onClick={() => setCurrentSlide(index)}
+                      className={`h-2 rounded-full transition-all ${
+                        index === currentSlide ? 'w-10 bg-black' : 'w-3 bg-black/50'
+                      }`}
+                      aria-label={`Go to slide ${index + 1}`}
+                    />
+                  ))}
                 </div>
-                <div className="flex flex-wrap gap-3">
-                  <button className="px-6 py-3 rounded-full border border-black bg-orange-100 text-black font-medium transition-colors hover:bg-orange-200">
-                    Explore solutions
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={() => setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length)}
+                    className="flex h-11 w-11 items-center justify-center rounded-full border border-black text-black transition-colors hover:bg-orange-200"
+                    aria-label="Previous slide"
+                  >
+                    <ChevronLeft size={20} />
                   </button>
-                  <button className="px-6 py-3 rounded-full border border-black text-black font-medium transition-colors hover:bg-orange-200">
-                    Talk to our team
+                  <button
+                    onClick={() => setCurrentSlide((prev) => (prev + 1) % slides.length)}
+                    className="flex h-11 w-11 items-center justify-center rounded-full border border-black text-black transition-colors hover:bg-orange-200"
+                    aria-label="Next slide"
+                  >
+                    <ChevronRight size={20} />
                   </button>
                 </div>
               </div>
+            </div>
+            <div className="lg:col-span-4">
+              <div className="relative h-full w-full min-h-[320px] overflow-hidden rounded-3xl">
+                <iframe
+                  src="https://my.spline.design/robotfollowcursorforlandingpage-WS2q4JW8psPctyWFuHDds2VX/"
+                  title="Interactive robot animation"
+                  frameBorder="0"
+                  className="h-full w-full"
+                  allowFullScreen
+                ></iframe>
+              </div>
+            </div>
+          </div>
 
+          <div className="bg-white border border-orange-100 rounded-[2.5rem] shadow-xl">
+            <div className="grid gap-10 p-10 lg:p-14 lg:grid-cols-2">
               {columnHighlights.map((highlight, index) => (
                 <div key={highlight.heading} className="flex flex-col justify-between rounded-3xl border border-orange-100 p-6 bg-orange-50">
                   <div className="space-y-4">
@@ -90,38 +131,6 @@ const Hero = () => {
                   <div className="mt-6 text-sm font-medium text-black">{`0${index + 1}`}</div>
                 </div>
               ))}
-            </div>
-
-            <div className="flex flex-col gap-4 border-t border-orange-100 px-10 py-6 lg:flex-row lg:items-center lg:justify-between">
-              <div className="flex items-center gap-2">
-                {slides.map((_, index) => (
-                  <button
-                    key={index}
-                    onClick={() => setCurrentSlide(index)}
-                    className={`h-2 rounded-full transition-all ${
-                      index === currentSlide ? 'w-10 bg-black' : 'w-3 bg-black/50'
-                    }`}
-                    aria-label={`Go to slide ${index + 1}`}
-                  />
-                ))}
-              </div>
-
-              <div className="flex items-center gap-3">
-                <button
-                  onClick={() => setCurrentSlide((prev) => (prev - 1 + slides.length) % slides.length)}
-                  className="flex h-11 w-11 items-center justify-center rounded-full border border-black text-black transition-colors hover:bg-orange-200"
-                  aria-label="Previous slide"
-                >
-                  <ChevronLeft size={20} />
-                </button>
-                <button
-                  onClick={() => setCurrentSlide((prev) => (prev + 1) % slides.length)}
-                  className="flex h-11 w-11 items-center justify-center rounded-full border border-black text-black transition-colors hover:bg-orange-200"
-                  aria-label="Next slide"
-                >
-                  <ChevronRight size={20} />
-                </button>
-              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- move the hero slider content above the highlighted cards and arrange it in an 8/4 grid alongside the embedded Spline iframe
- keep the highlight cards inside the bordered container while relocating the slider controls with the hero content

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d2dd6a20d88331a334a1bce6f12c2c