### PR TITLE
Ensure consistent orange background across sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,9 +45,9 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-white">
+    <div className="min-h-screen bg-orange-100">
       <Header currentPage={currentPage} setCurrentPage={setCurrentPage} />
-      <main className="pt-16">
+      <main className="pt-16 bg-orange-100">
         {renderPage()}
       </main>
       <Footer currentPage={currentPage} setCurrentPage={setCurrentPage} />

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -31,8 +31,8 @@ const About = () => {
   return (
     <div className="pt-20">
       {/* Hero Section */}
-      <section className="py-24 bg-gradient-to-br from-light-green/20 via-white to-peach/20">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-light-green/20 via-orange-100 to-peach/20">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h1 className="font-title text-5xl lg:text-6xl font-bold text-black/90 mb-6">About The Run Sun</h1>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto leading-relaxed">
@@ -90,8 +90,8 @@ const About = () => {
       </section>
 
       {/* Values Section */}
-      <section className="py-24 bg-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h2 className="font-title text-4xl font-bold text-black/90 mb-6">Our Values</h2>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto">
@@ -111,8 +111,8 @@ const About = () => {
       </section>
 
       {/* Mission & Vision */}
-      <section className="py-24 bg-gradient-to-br from-olivine/10 to-light-green/20">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-olivine/10 to-light-green/20">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid lg:grid-cols-2 gap-16">
             <div className="bg-white rounded-3xl p-10 shadow-lg">
               <h3 className="font-title text-3xl font-bold text-black/90 mb-6">Our Mission</h3>

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -48,8 +48,8 @@ const Contact = () => {
   return (
     <div className="pt-20">
       {/* Hero Section */}
-      <section className="py-24 bg-gradient-to-br from-red-ncs/10 via-white to-olivine/10">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-red-ncs/10 via-orange-100 to-olivine/10">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h1 className="font-title text-5xl lg:text-6xl font-bold text-black/90 mb-6">Contact Us</h1>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto">
@@ -167,8 +167,8 @@ const Contact = () => {
       </section>
 
       {/* Map Section */}
-      <section className="py-16 bg-gray-100">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-16 bg-orange-100">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="bg-white rounded-3xl overflow-hidden shadow-lg">
             <div className="aspect-video bg-gradient-to-br from-light-green/20 to-olivine/20 flex items-center justify-center">
               <div className="text-center">

--- a/src/components/EthicalAI.tsx
+++ b/src/components/EthicalAI.tsx
@@ -57,8 +57,8 @@ const EthicalAI = () => {
   return (
     <div className="pt-20">
       {/* Hero Section */}
-      <section className="py-24 bg-gradient-to-br from-light-green/10 via-white to-light-green/20">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-light-green/10 via-orange-100 to-light-green/20">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <div className="w-20 h-20 bg-red-ncs rounded-full flex items-center justify-center mx-auto mb-6">
               <Brain className="w-10 h-10 text-white" />
@@ -102,8 +102,8 @@ const EthicalAI = () => {
       </section>
 
       {/* Principles Section */}
-      <section className="py-24 bg-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h2 className="font-title text-4xl font-bold text-black/90 mb-6">Our Ethical AI Principles</h2>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto">
@@ -129,8 +129,8 @@ const EthicalAI = () => {
       </section>
 
       {/* Initiatives Section */}
-      <section className="py-24 bg-gradient-to-br from-olivine/10 to-light-green/20">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-olivine/10 to-light-green/20">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h2 className="font-title text-4xl font-bold text-black/90 mb-6">Our Initiatives</h2>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto">

--- a/src/components/LogoShowcase.tsx
+++ b/src/components/LogoShowcase.tsx
@@ -11,8 +11,8 @@ const LogoShowcase = () => {
   ];
 
   return (
-    <section className="py-32 bg-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="py-32 bg-orange-100">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-20">
           <p className="text-2xl text-black/90 mb-8">
             Trusted by forward-thinking companies around the world

--- a/src/components/Products.tsx
+++ b/src/components/Products.tsx
@@ -44,8 +44,8 @@ const Products = () => {
   ];
 
   return (
-    <section id="products" className="py-32 bg-orange-50">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section id="products" className="py-32 bg-orange-100">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-20">
           <h2 className="text-5xl font-title font-bold text-black/90 mb-6">Our Products</h2>
           <p className="text-xl font-body text-black/90/70 max-w-3xl mx-auto">

--- a/src/components/ProjectQuote.tsx
+++ b/src/components/ProjectQuote.tsx
@@ -83,7 +83,7 @@ const ProjectQuote = () => {
 
   if (step === 4) {
     return (
-      <div className="pt-20 min-h-screen bg-gradient-to-br from-light-green/20 to-olivine/20 flex items-center justify-center">
+      <div className="pt-20 min-h-screen bg-orange-100 bg-gradient-to-br from-light-green/20 to-olivine/20 flex items-center justify-center">
         <div className="max-w-2xl mx-auto px-4 text-center">
           <div className="bg-white rounded-3xl p-12 shadow-2xl">
             <div className="w-20 h-20 bg-light-green rounded-full flex items-center justify-center mx-auto mb-8">
@@ -124,7 +124,7 @@ const ProjectQuote = () => {
   }
 
   return (
-    <div className="pt-20 min-h-screen bg-gradient-to-br from-peach/10 via-white to-red-ncs/5">
+    <div className="pt-20 min-h-screen bg-orange-100 bg-gradient-to-br from-peach/10 via-orange-100 to-red-ncs/5">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
         <div className="text-center mb-12">
           <h1 className="font-title text-5xl font-bold text-black/90 mb-6">Get Your Project Quote</h1>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -32,8 +32,8 @@ const Services = () => {
   ];
 
   return (
-    <section id="services" className="py-32 bg-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section id="services" className="py-32 bg-orange-100">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-20">
           <h2 className="text-5xl font-title font-bold text-black/90 mb-6">Our Services</h2>
           <p className="text-xl font-body text-black/90/70 max-w-3xl mx-auto">

--- a/src/components/Sustainability.tsx
+++ b/src/components/Sustainability.tsx
@@ -67,8 +67,8 @@ const Sustainability = () => {
   return (
     <div className="pt-20">
       {/* Hero Section */}
-      <section className="py-24 bg-gradient-to-br from-light-green/20 via-white to-olivine/30">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-light-green/20 via-orange-100 to-olivine/30">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <div className="w-20 h-20 bg-olivine rounded-full flex items-center justify-center mx-auto mb-6">
               <Leaf className="w-10 h-10 text-white" />
@@ -111,8 +111,8 @@ const Sustainability = () => {
       </section>
 
       {/* Initiatives Section */}
-      <section className="py-24 bg-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h2 className="font-title text-4xl font-bold text-black/90 mb-6">Our Green Initiatives</h2>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto">
@@ -141,8 +141,8 @@ const Sustainability = () => {
       </section>
 
       {/* Goals Timeline */}
-      <section className="py-24 bg-gray-50">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="py-24 bg-orange-100">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-20">
             <h2 className="font-title text-4xl font-bold text-black/90 mb-6">Sustainability Roadmap</h2>
             <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto">
@@ -170,7 +170,7 @@ const Sustainability = () => {
 
       {/* Impact Stats */}
       <section className="py-24 bg-olivine text-white">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="font-title text-4xl font-bold mb-6">Our Environmental Impact</h2>
             <p className="font-body text-xl text-white/80 max-w-3xl mx-auto">
@@ -200,8 +200,8 @@ const Sustainability = () => {
       </section>
 
       {/* CTA Section */}
-      <section className="py-24 bg-gradient-to-br from-light-green/20 to-olivine/20">
-  <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <section className="py-24 bg-orange-100 bg-gradient-to-br from-light-green/20 to-olivine/20">
+        <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="font-title text-4xl font-bold text-black/90 mb-6">Join Our Sustainability Journey</h2>
           <p className="font-body text-xl text-black/90/70 max-w-3xl mx-auto mb-10">
             Partner with us to build sustainable technology solutions that benefit both your business and the environment.

--- a/src/components/VideoSection.tsx
+++ b/src/components/VideoSection.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 
 const VideoSection = () => {
   return (
-    <section className="py-32 bg-gray-50">
-<div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="py-32 bg-orange-100">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
 	<div className="grid lg:grid-cols-[2fr_1fr] gap-20 items-center">
 		{/* Video Side */}
           <div className="relative">


### PR DESCRIPTION
## Summary
- update each major page section to use the shared `bg-orange-100` background or gradient overlays that include it
- refresh hero gradients so they retain their styling while keeping the orange base color

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5f3e3b5f0833181f7d8f9e4e7b90b