### PR TITLE
Add tech stack landing page and detail navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,11 @@ import EthicalAI from './components/EthicalAI';
 import Sustainability from './components/Sustainability';
 import ProjectQuote from './components/ProjectQuote';
 import Footer from './components/Footer';
+import TechStacks from './components/TechStacks';
+import LeanStack from './components/tech-stacks/LeanStack';
+import MeanStack from './components/tech-stacks/MeanStack';
+import LampStack from './components/tech-stacks/LampStack';
+import WampStack from './components/tech-stacks/WampStack';
 
 function App() {
   const [currentPage, setCurrentPage] = useState('home');
@@ -20,7 +25,7 @@ function App() {
       case 'about':
         return <About />;
       case 'services':
-        return <Services />;
+        return <Services setCurrentPage={setCurrentPage} />;
       case 'products':
         return <Products />;
       case 'contact':
@@ -31,13 +36,23 @@ function App() {
         return <Sustainability />;
       case 'quote':
         return <ProjectQuote />;
+      case 'tech-stacks':
+        return <TechStacks setCurrentPage={setCurrentPage} />;
+      case 'tech-stack-lean':
+        return <LeanStack setCurrentPage={setCurrentPage} />;
+      case 'tech-stack-mean':
+        return <MeanStack setCurrentPage={setCurrentPage} />;
+      case 'tech-stack-lamp':
+        return <LampStack setCurrentPage={setCurrentPage} />;
+      case 'tech-stack-wamp':
+        return <WampStack setCurrentPage={setCurrentPage} />;
       default:
         return (
           <>
             <Hero />
             <LogoShowcase />
             <VideoSection />
-            <Services />
+            <Services setCurrentPage={setCurrentPage} />
             <Products />
           </>
         );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -28,6 +28,13 @@ const Footer: React.FC<FooterProps> = ({ setCurrentPage }) => {
       { name: 'Sustainability', id: 'sustainability' },
       { name: 'Contact', id: 'contact' },
     ],
+    stacks: [
+      { name: 'Overview', id: 'tech-stacks' },
+      { name: 'LEAN Stack', id: 'tech-stack-lean' },
+      { name: 'MEAN Stack', id: 'tech-stack-mean' },
+      { name: 'LAMP Stack', id: 'tech-stack-lamp' },
+      { name: 'WAMP Stack', id: 'tech-stack-wamp' },
+    ],
   };
 
   return (
@@ -89,7 +96,7 @@ const Footer: React.FC<FooterProps> = ({ setCurrentPage }) => {
               </div>
 
               {/* Navigation Links */}
-              <div className="grid gap-10 md:grid-cols-3 lg:col-span-3">
+              <div className="grid gap-10 md:grid-cols-3 lg:grid-cols-4 lg:col-span-3">
                 <div>
                   <h3 className="text-lg font-semibold mb-4 text-black">Company</h3>
                   <ul className="space-y-2">
@@ -126,6 +133,22 @@ const Footer: React.FC<FooterProps> = ({ setCurrentPage }) => {
                   <h3 className="text-lg font-semibold mb-4 text-black">Resources</h3>
                   <ul className="space-y-2 text-black">
                     {navigation.resources.map((item) => (
+                      <li key={item.name}>
+                        <button
+                          onClick={() => setCurrentPage(item.id)}
+                          className="text-black transition-opacity hover:opacity-80"
+                        >
+                          {item.name}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div>
+                  <h3 className="text-lg font-semibold mb-4 text-black">Tech Stacks</h3>
+                  <ul className="space-y-2 text-black">
+                    {navigation.stacks.map((item) => (
                       <li key={item.name}>
                         <button
                           onClick={() => setCurrentPage(item.id)}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,15 +9,25 @@ interface HeaderProps {
 const Header: React.FC<HeaderProps> = ({ currentPage, setCurrentPage }) => {
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
 
-	const navigation = [
-		{ name: 'Home', id: 'home' },
-		{ name: 'About', id: 'about' },
-		{ name: 'Services', id: 'services' },
-		{ name: 'Products', id: 'products' },
-		{ name: 'Ethical AI', id: 'ethical-ai' },
-		{ name: 'Sustainability', id: 'sustainability' },
-		{ name: 'Contact', id: 'contact' },
-	];
+        const navigation = [
+                { name: 'Home', id: 'home' },
+                { name: 'About', id: 'about' },
+                { name: 'Services', id: 'services' },
+                { name: 'Products', id: 'products' },
+                { name: 'Ethical AI', id: 'ethical-ai' },
+                { name: 'Sustainability', id: 'sustainability' },
+                { name: 'Tech Stacks', id: 'tech-stacks' },
+                { name: 'Contact', id: 'contact' },
+        ];
+
+        const stackNavigation = [
+                { name: 'LEAN', id: 'tech-stack-lean' },
+                { name: 'MEAN', id: 'tech-stack-mean' },
+                { name: 'LAMP', id: 'tech-stack-lamp' },
+                { name: 'WAMP', id: 'tech-stack-wamp' },
+        ];
+
+        const isStackPage = currentPage === 'tech-stacks' || currentPage.startsWith('tech-stack');
 
         return (
                 <header className="fixed top-0 left-0 right-0 z-50 bg-orange-100">
@@ -53,6 +63,27 @@ const Header: React.FC<HeaderProps> = ({ currentPage, setCurrentPage }) => {
                                                         Get Quote
                                                 </button>
                                         </nav>
+
+                                        {/* Desktop Stack Navigation */}
+                                        {isStackPage && (
+                                                <div className="hidden lg:block">
+                                                        <div className="flex space-x-4">
+                                                                {stackNavigation.map((item) => (
+                                                                        <button
+                                                                                key={item.id}
+                                                                                onClick={() => setCurrentPage(item.id)}
+                                                                                className={`text-sm font-semibold uppercase tracking-[0.3em] transition-opacity ${
+                                                                                        currentPage === item.id
+                                                                                                ? 'opacity-100'
+                                                                                                : 'opacity-60 hover:opacity-100'
+                                                                                }`}
+                                                                        >
+                                                                                {item.name}
+                                                                        </button>
+                                                                ))}
+                                                        </div>
+                                                </div>
+                                        )}
 
                                         {/* Mobile menu button */}
                                         <button
@@ -91,9 +122,55 @@ const Header: React.FC<HeaderProps> = ({ currentPage, setCurrentPage }) => {
                                                         >
                                                                 Get Quote
                                                         </button>
+
+                                                        <div className="pt-6 border-t border-black/10">
+                                                                <p className="px-4 text-xs font-semibold uppercase tracking-[0.3em] text-black/60">
+                                                                        Tech Stacks
+                                                                </p>
+                                                                <div className="mt-3 space-y-2">
+                                                                        {stackNavigation.map((item) => (
+                                                                                <button
+                                                                                        key={item.id}
+                                                                                        onClick={() => {
+                                                                                                setCurrentPage(item.id);
+                                                                                                setIsMenuOpen(false);
+                                                                                        }}
+                                                                                        className={`block w-full text-left px-4 py-2 rounded-lg transition-opacity ${
+                                                                                                currentPage === item.id
+                                                                                                        ? 'opacity-100 bg-white'
+                                                                                                        : 'opacity-70 hover:opacity-100 hover:bg-white/70'
+                                                                                        }`}
+                                                                                >
+                                                                                        {item.name} Stack
+                                                                                </button>
+                                                                        ))}
+                                                                </div>
+                                                        </div>
                                                 </nav>
                                         </div>
                                 )}
+                        {isStackPage && (
+                                <div className="hidden lg:block border-t border-black/10 bg-orange-100/60">
+                                        <div className="px-4 sm:px-6 lg:px-10 py-3 flex items-center space-x-6">
+                                                <span className="text-xs font-semibold uppercase tracking-[0.4em] text-black/60">
+                                                        Tech Stacks
+                                                </span>
+                                                {stackNavigation.map((item) => (
+                                                        <button
+                                                                key={item.id}
+                                                                onClick={() => setCurrentPage(item.id)}
+                                                                className={`text-sm font-medium transition-opacity ${
+                                                                        currentPage === item.id
+                                                                                ? 'opacity-100 underline'
+                                                                                : 'opacity-60 hover:opacity-100'
+                                                                }`}
+                                                        >
+                                                                {item.name} Stack
+                                                        </button>
+                                                ))}
+                                        </div>
+                                </div>
+                        )}
                         </div>
                 </header>
         );

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,57 +1,65 @@
 import React, { useState } from 'react';
 import { Code, Cloud, Cpu, Smartphone } from 'lucide-react';
 
-const Services = () => {
+interface ServicesProps {
+  setCurrentPage: (page: string) => void;
+}
+
+const Services: React.FC<ServicesProps> = ({ setCurrentPage }) => {
   const [hoveredService, setHoveredService] = useState<number | null>(null);
 
   const services = [
     {
       icon: <Code className="w-8 h-8" />,
-      title: "Visionary Web Application Engineering",
+      title: 'LEAN Stack Launchpads',
       description:
-        "We imagine ethical, human web experiences that scale across LEAN, MEAN, LAMP, and WAMP stacks without losing soul.",
+        'Launch human-centred MVPs with our LEAN experimentation squads guiding research, product strategy, and responsible automation.',
       features: [
-        "Ethical architecture reviews across LEAN, MEAN, LAMP, and WAMP foundations",
-        "C#, PHP, and JavaScript/ECMAScript framework fluency that empowers every sprint",
-        "Human-centered journey mapping that keeps teams inspired and accountable",
-        "Imaginative accessibility and analytics enhancements woven into each release",
+        'Design sprint facilitation, journey mapping, and inclusive research rituals',
+        'Serverless and headless engineering to validate ideas quickly',
+        'Telemetry starter kits and analytics that spotlight insight-rich signals',
+        'Innovation governance frameworks that respect your values',
       ],
+      target: 'tech-stack-lean',
     },
     {
       icon: <Smartphone className="w-8 h-8" />,
-      title: "Empowering Mobile Experience Design",
+      title: 'MEAN Stack Experience Platforms',
       description:
-        "Our imaginative mobile artisans craft native and hybrid journeys that feel visionary, inclusive, and trustworthy.",
+        'Shape cohesive TypeScript products that scale globally with real-time collaboration, personalisation, and accessible design systems.',
       features: [
-        "Objective-C and Swift craftsmanship for ethically minded iOS launches",
-        "Java, Kotlin, and Flutter brilliance delivering empowering Android stories",
-        "Cross-platform mentoring that keeps code humane and imaginative",
-        "Human insight labs that translate field feedback into delightful iterations",
+        'TypeScript-first engineering spanning MongoDB, Express, Angular, and Node',
+        'Design system operations with inclusive component libraries',
+        'Automated quality pipelines covering performance and accessibility',
+        'Cloud optimisation strategies that reduce cost and carbon',
       ],
+      target: 'tech-stack-mean',
     },
     {
       icon: <Cloud className="w-8 h-8" />,
-      title: "Desktop Continuity & Cloud Harmony",
+      title: 'LAMP Stack Revitalisation',
       description:
-        "We unite visionary desktop craftsmanship with cloud imagination so every touchpoint remains grounded, secure, and kind.",
+        'Modernise PHP ecosystems with composable architectures, accessibility enhancements, and automation that respects governance.',
       features: [
-        "C# and .NET packaging that keeps Windows ecosystems empowering and reliable",
-        "Electron and progressive desktop experiences grown from ethical JavaScript cores",
-        "Lean automation that synchronizes updates without compromising trust",
-        "Human support rituals that celebrate teams while safeguarding every device",
+        'Laravel, Symfony, and WordPress engineering guided by domain-driven design',
+        'Composable CMS integrations with marketing and data platforms',
+        'WCAG 2.2 AA accessibility audits baked into releases',
+        'Blue-green deployment pipelines and observability dashboards',
       ],
+      target: 'tech-stack-lamp',
     },
     {
       icon: <Cpu className="w-8 h-8" />,
-      title: "Product Engineering & Automation",
+      title: 'WAMP Stack Modernisation',
       description:
-        "We accelerate products with imaginative automation that honors people, amplifies impact, and respects every ecosystem.",
+        'Connect Windows-native ecosystems with secure portals, field service tooling, and IoT command centres that feel effortless.',
       features: [
-        "End-to-end product acceleration spanning LEAN, MEAN, LAMP, and WAMP landscapes",
-        "Ethical automation pipelines blending C#, PHP, and ECMAScript ingenuity",
-        "AI-assisted instrumentation with human oversight for visionary resilience",
-        "Empowering workshops that align stakeholders around compassionate innovation",
+        'Azure, IIS, and on-premises integration for hybrid environments',
+        'Single sign-on, MFA, and zero-trust architecture expertise',
+        'Offline-first app design for rugged devices and field teams',
+        'Lifecycle automation for packaging, updates, and monitoring',
       ],
+      target: 'tech-stack-wamp',
     },
   ];
 
@@ -93,7 +101,10 @@ const Services = () => {
                 ))}
               </ul>
               
-              <button className="mt-6 text-red-ncs font-title font-medium hover:text-red-ncs/80 transition-colors group-hover:translate-x-2 transition-transform inline-flex items-center">
+              <button
+                onClick={() => setCurrentPage(service.target)}
+                className="mt-6 text-red-ncs font-title font-medium hover:text-red-ncs/80 transition-colors group-hover:translate-x-2 transition-transform inline-flex items-center"
+              >
                 Learn More
                 <span className="ml-2">→</span>
               </button>

--- a/src/components/TechStacks.tsx
+++ b/src/components/TechStacks.tsx
@@ -1,0 +1,142 @@
+import React from 'react';
+import { ArrowRight, Layers, Rocket, Sparkles } from 'lucide-react';
+
+interface TechStacksProps {
+  setCurrentPage: (page: string) => void;
+}
+
+const stacks = [
+  {
+    id: 'tech-stack-lean',
+    name: 'LEAN Stack',
+    tagline: 'Rapid validation with empathetic user discovery and lean delivery rituals.',
+    description:
+      'Ideal for ventures exploring new markets or internal teams seeking to test concepts quickly. Our LEAN practice pairs iterative product coaching with purposeful automation to keep launches human-centred.',
+    image:
+      'https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1200&q=80',
+    highlights: [
+      'Design sprints paired with ethical AI research loops',
+      'Cross-functional pods guiding MVPs from concept to insight',
+      'Observability playbooks tuned for rapid course correction',
+    ],
+    cta: 'Explore LEAN Engagements',
+  },
+  {
+    id: 'tech-stack-mean',
+    name: 'MEAN Stack',
+    tagline: 'Cloud-native JavaScript platforms crafted for immersive, scalable digital journeys.',
+    description:
+      'Our MEAN specialists shape cohesive TypeScript experiences across MongoDB, Express, Angular, and Node. We coach teams to evolve multi-channel products with responsibility and imagination.',
+    image:
+      'https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=1200&q=80',
+    highlights: [
+      'Full-stack TypeScript acceleration with shared design systems',
+      'Realtime collaboration and media streaming accelerators',
+      'Performance, security, and sustainability dashboards baked in',
+    ],
+    cta: 'Dive into MEAN Delivery',
+  },
+  {
+    id: 'tech-stack-lamp',
+    name: 'LAMP Stack',
+    tagline: 'Modernised PHP ecosystems infused with automation, accessibility, and trust.',
+    description:
+      'We rejuvenate mission-critical platforms with Laravel, WordPress, and bespoke PHP frameworks. Our approach balances reliability, compliance, and captivating storytelling.',
+    image:
+      'https://images.unsplash.com/photo-1483478550801-ceba5fe50e8e?auto=format&fit=crop&w=1200&q=80',
+    highlights: [
+      'Composable content architectures and globalised localisation',
+      'Commerce, membership, and community accelerators',
+      'DevSecOps pipelines orchestrated for regulated industries',
+    ],
+    cta: 'Reimagine LAMP Solutions',
+  },
+  {
+    id: 'tech-stack-wamp',
+    name: 'WAMP Stack',
+    tagline: 'Windows-native craftsmanship connecting desktop, mobile, and IoT experiences.',
+    description:
+      'From industrial control rooms to field service, our WAMP engineering unifies Windows, Apache, MySQL, and PHP with modern UX and low-code augmentation.',
+    image:
+      'https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=1200&q=80',
+    highlights: [
+      'Secure intranet and partner portals with Azure Active Directory',
+      'Offline-first field applications and rugged device enablement',
+      'Data visualisation layers bridging Power BI and custom dashboards',
+    ],
+    cta: 'Activate WAMP Innovation',
+  },
+];
+
+const TechStacks: React.FC<TechStacksProps> = ({ setCurrentPage }) => {
+  return (
+    <section className="bg-orange-100 min-h-screen py-24">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-16 text-center">
+          <span className="inline-flex items-center space-x-2 text-red-ncs font-medium uppercase tracking-widest">
+            <Layers className="w-4 h-4" />
+            <span>Technology ecosystems</span>
+          </span>
+          <h1 className="mt-6 text-5xl md:text-6xl font-title font-bold text-black">Crafted stacks for courageous teams</h1>
+          <p className="mt-6 text-lg md:text-xl text-black/70 max-w-3xl mx-auto">
+            Our architects co-design technology foundations that balance innovation with accountability. Explore the
+            delivery patterns, cultural practices, and accelerators behind each of our signature stacks.
+          </p>
+        </div>
+
+        <div className="grid gap-10 lg:grid-cols-2">
+          {stacks.map((stack) => (
+            <article
+              key={stack.id}
+              className="relative overflow-hidden rounded-3xl border border-black/10 bg-white shadow-[0_20px_60px_-25px_rgba(0,0,0,0.25)]"
+            >
+              <div className="grid md:grid-cols-[1.2fr_1fr]">
+                <div className="p-10 flex flex-col justify-between space-y-10">
+                  <div className="space-y-6">
+                    <div className="inline-flex items-center space-x-2 text-sm uppercase tracking-[0.2em] text-red-ncs/80">
+                      <Rocket className="w-4 h-4" />
+                      <span>{stack.name}</span>
+                    </div>
+                    <h2 className="text-3xl md:text-4xl font-title font-bold text-black">{stack.tagline}</h2>
+                    <p className="text-base md:text-lg text-black/70">{stack.description}</p>
+                  </div>
+
+                  <ul className="space-y-3">
+                    {stack.highlights.map((highlight) => (
+                      <li key={highlight} className="flex items-start space-x-3 text-black/80">
+                        <Sparkles className="w-5 h-5 mt-1 text-red-ncs" />
+                        <span>{highlight}</span>
+                      </li>
+                    ))}
+                  </ul>
+
+                  <div>
+                    <button
+                      onClick={() => setCurrentPage(stack.id)}
+                      className="inline-flex items-center space-x-2 rounded-full bg-red-ncs px-6 py-3 font-title text-white shadow-lg transition-transform hover:-translate-y-0.5 hover:bg-red-ncs/90"
+                    >
+                      <span>{stack.cta}</span>
+                      <ArrowRight className="w-5 h-5" />
+                    </button>
+                  </div>
+                </div>
+                <div className="relative h-full min-h-[280px]">
+                  <div
+                    className="absolute inset-0"
+                    style={{
+                      backgroundImage: `linear-gradient(180deg, rgba(0,0,0,0.15), rgba(0,0,0,0.45)), url(${stack.image})`,
+                      backgroundSize: 'cover',
+                      backgroundPosition: 'center',
+                    }}
+                  />
+                </div>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TechStacks;

--- a/src/components/tech-stacks/LampStack.tsx
+++ b/src/components/tech-stacks/LampStack.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import TechStackDetailTemplate from './TechStackDetailTemplate';
+
+interface StackProps {
+  setCurrentPage: (page: string) => void;
+}
+
+const LampStack: React.FC<StackProps> = ({ setCurrentPage }) => {
+  return (
+    <TechStackDetailTemplate
+      name="LAMP Stack"
+      kicker="PHP revitalisation"
+      headline="Sustainable platforms powered by modern PHP craftsmanship"
+      description="From heritage intranets to global publishing platforms, we evolve LAMP estates with automation, accessibility, and security at the core."
+      heroImage="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=1600&q=80"
+      appTypes={[
+        {
+          title: 'Digital publishing ecosystems',
+          description:
+            'Upgrade content-heavy destinations with headless WordPress, Drupal, or Laravel, seamlessly connected to marketing suites.',
+        },
+        {
+          title: 'Commerce and subscription platforms',
+          description:
+            'Launch multi-region storefronts, membership hubs, and donation portals tuned for conversions and reliability.',
+        },
+        {
+          title: 'Regulated sector portals',
+          description:
+            'Replatform healthcare, finance, and public service portals with audited workflows and adaptive authentication.',
+        },
+        {
+          title: 'Knowledge and learning systems',
+          description:
+            'Deliver LMS and knowledge bases with multi-language support, adaptive search, and progressive web app experiences.',
+        },
+      ]}
+      capabilities={[
+        'Laravel and Symfony engineering with domain-driven design',
+        'Composable CMS architectures with GraphQL/REST bridges',
+        'Automated QA covering accessibility, localisation, and security',
+        'Infrastructure modernisation across AWS, Azure, and on-prem',
+      ]}
+      accelerators={[
+        'Migration toolkits for WordPress, Drupal, and legacy PHP apps',
+        'Component libraries aligned to WCAG 2.2 AA accessibility',
+        'Blue-green deployment playbooks with rollback readiness',
+        'Data privacy assessments and consent orchestration frameworks',
+      ]}
+      setCurrentPage={setCurrentPage}
+      cta={{ label: 'Discuss LAMP transformation', target: 'quote' }}
+    />
+  );
+};
+
+export default LampStack;

--- a/src/components/tech-stacks/LeanStack.tsx
+++ b/src/components/tech-stacks/LeanStack.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import TechStackDetailTemplate from './TechStackDetailTemplate';
+
+interface StackProps {
+  setCurrentPage: (page: string) => void;
+}
+
+const LeanStack: React.FC<StackProps> = ({ setCurrentPage }) => {
+  return (
+    <TechStackDetailTemplate
+      name="LEAN Stack"
+      kicker="Lean experimentation"
+      headline="Human-centred MVPs that learn in weeks, not quarters"
+      description="We partner with founders and intrapreneurs to validate propositions with empathy. From hypothesis design to continuous delivery, our LEAN squads keep feedback loops short and purposeful."
+      heroImage="https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=1600&q=80"
+      appTypes={[
+        {
+          title: 'Customer discovery platforms',
+          description:
+            'Launch insight-rich portals that blend surveys, diary studies, and analytics to surface signals for next-sprint decisions.',
+        },
+        {
+          title: 'Operational experimentation apps',
+          description:
+            'Spin up internal workflow pilots connecting Airtable, low-code tooling, and bespoke services to validate process change.',
+        },
+        {
+          title: 'Ethical AI proof-of-concepts',
+          description:
+            'Test AI-driven experiences with governance guardrails, bias audits, and curated datasets aligned with your principles.',
+        },
+        {
+          title: 'Service design companion apps',
+          description:
+            'Equip design teams with journey orchestration tools that keep human stories at the centre of iteration.',
+        },
+      ]}
+      capabilities={[
+        'Product strategy facilitation and hypothesis backlogs',
+        'Design sprint coaching with inclusive research methods',
+        'Serverless and headless engineering for rapid assembly',
+        'Observability and analytics dashboards tailored for MVPs',
+      ]}
+      accelerators={[
+        'MVP telemetry starter kits with privacy-first instrumentation',
+        'Ethical AI readiness assessments with cross-functional workshops',
+        'Reusable design system foundations for rapid prototyping',
+        'Innovation governance frameworks aligned to your culture',
+      ]}
+      setCurrentPage={setCurrentPage}
+      cta={{ label: 'Co-create a LEAN roadmap', target: 'quote' }}
+    />
+  );
+};
+
+export default LeanStack;

--- a/src/components/tech-stacks/MeanStack.tsx
+++ b/src/components/tech-stacks/MeanStack.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import TechStackDetailTemplate from './TechStackDetailTemplate';
+
+interface StackProps {
+  setCurrentPage: (page: string) => void;
+}
+
+const MeanStack: React.FC<StackProps> = ({ setCurrentPage }) => {
+  return (
+    <TechStackDetailTemplate
+      name="MEAN Stack"
+      kicker="Full-stack JavaScript"
+      headline="Composable TypeScript platforms that scale with your audience"
+      description="Our MEAN guild blends product strategy, design systems, and cloud automation to nurture resilient customer experiences. We help teams unlock velocity across MongoDB, Express, Angular, and Node."
+      heroImage="https://images.unsplash.com/photo-1523475472560-d2df97ec485c?auto=format&fit=crop&w=1600&q=80"
+      appTypes={[
+        {
+          title: 'Digital experience platforms',
+          description:
+            'Craft editorial, commerce, and membership journeys with component-driven frontends and composable back-office tooling.',
+        },
+        {
+          title: 'Realtime collaboration products',
+          description:
+            'Deliver event-driven whiteboards, messaging, and co-creation tools with websockets, WebRTC, and thoughtful moderation.',
+        },
+        {
+          title: 'Data-rich analytics portals',
+          description:
+            'Visualise streaming datasets with Angular and D3, blending interactive dashboards and alerting that scale globally.',
+        },
+        {
+          title: 'API-first partner ecosystems',
+          description:
+            'Launch secure developer portals and monetised APIs with rate-limiting, subscription workflows, and usage insights.',
+        },
+      ]}
+      capabilities={[
+        'TypeScript-first engineering with shared UI libraries',
+        'Microservices architecture and GraphQL federation',
+        'Automated testing pipelines spanning API, UI, and accessibility',
+        'Cost, carbon, and performance optimisation playbooks',
+      ]}
+      accelerators={[
+        'Design system starter kits with Storybook governance',
+        'Infrastructure as Code templates for Kubernetes and serverless',
+        'Observability bundles integrating OpenTelemetry and Elastic',
+        'Compliance frameworks for SOC 2 and GDPR readiness',
+      ]}
+      setCurrentPage={setCurrentPage}
+      cta={{ label: 'Schedule a MEAN discovery', target: 'quote' }}
+    />
+  );
+};
+
+export default MeanStack;

--- a/src/components/tech-stacks/TechStackDetailTemplate.tsx
+++ b/src/components/tech-stacks/TechStackDetailTemplate.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { ArrowLeft, ArrowRight, Layers, Sparkles } from 'lucide-react';
+
+interface AppType {
+  title: string;
+  description: string;
+}
+
+interface CTAConfig {
+  label: string;
+  target: string;
+}
+
+export interface TechStackDetailTemplateProps {
+  name: string;
+  kicker: string;
+  headline: string;
+  description: string;
+  heroImage: string;
+  appTypes: AppType[];
+  capabilities: string[];
+  accelerators: string[];
+  setCurrentPage: (page: string) => void;
+  cta?: CTAConfig;
+}
+
+const TechStackDetailTemplate: React.FC<TechStackDetailTemplateProps> = ({
+  name,
+  kicker,
+  headline,
+  description,
+  heroImage,
+  appTypes,
+  capabilities,
+  accelerators,
+  setCurrentPage,
+  cta,
+}) => {
+  return (
+    <section className="bg-orange-100 min-h-screen py-24">
+      <div className="max-w-screen-2xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-12 flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+          <button
+            onClick={() => setCurrentPage('tech-stacks')}
+            className="inline-flex items-center space-x-2 text-sm font-semibold text-red-ncs transition-colors hover:text-red-ncs/80"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            <span>Back to Tech Stacks</span>
+          </button>
+
+          <div className="flex items-center space-x-3 text-sm uppercase tracking-[0.3em] text-red-ncs/80">
+            <Layers className="w-4 h-4" />
+            <span>{name}</span>
+          </div>
+        </div>
+
+        <div className="relative overflow-hidden rounded-[3rem] border border-black/10 bg-white">
+          <div
+            className="relative h-72 w-full"
+            style={{
+              backgroundImage: `linear-gradient(180deg, rgba(12,12,12,0.1) 0%, rgba(12,12,12,0.5) 100%), url(${heroImage})`,
+              backgroundPosition: 'center',
+              backgroundSize: 'cover',
+            }}
+          >
+            <div className="absolute inset-0 flex items-end">
+              <div className="w-full p-10 text-white">
+                <p className="text-sm uppercase tracking-[0.4em] text-white/80">{kicker}</p>
+                <h1 className="mt-4 text-4xl md:text-5xl font-title font-bold">{headline}</h1>
+                <p className="mt-4 max-w-3xl text-lg text-white/85">{description}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-10 p-10 md:grid-cols-[1.1fr_0.9fr]">
+            <div className="space-y-10">
+              <div>
+                <h2 className="text-2xl font-title font-bold text-black">Representative experiences</h2>
+                <div className="mt-6 grid gap-6 md:grid-cols-2">
+                  {appTypes.map((app) => (
+                    <div key={app.title} className="rounded-3xl border border-black/10 bg-orange-50/60 p-6">
+                      <h3 className="text-xl font-semibold text-black">{app.title}</h3>
+                      <p className="mt-3 text-sm text-black/70">{app.description}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <div>
+                <h2 className="text-2xl font-title font-bold text-black">Core capabilities</h2>
+                <ul className="mt-6 space-y-3">
+                  {capabilities.map((capability) => (
+                    <li key={capability} className="flex items-start space-x-3 text-black/80">
+                      <Sparkles className="mt-1 w-5 h-5 text-red-ncs" />
+                      <span>{capability}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+
+            <div className="space-y-8">
+              <div className="rounded-3xl border border-black/10 bg-gradient-to-br from-red-ncs/10 via-white to-orange-100 p-8">
+                <h2 className="text-xl font-title font-semibold text-black">Delivery accelerators</h2>
+                <ul className="mt-4 space-y-3 text-black/80">
+                  {accelerators.map((accelerator) => (
+                    <li key={accelerator} className="flex items-start space-x-3">
+                      <Sparkles className="mt-1 w-5 h-5 text-red-ncs" />
+                      <span>{accelerator}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+
+              {cta && (
+                <button
+                  onClick={() => setCurrentPage(cta.target)}
+                  className="w-full rounded-full bg-red-ncs px-6 py-4 text-lg font-title font-semibold text-white shadow-lg transition-transform hover:-translate-y-0.5 hover:bg-red-ncs/90"
+                >
+                  <span className="inline-flex items-center justify-center space-x-2">
+                    <span>{cta.label}</span>
+                    <ArrowRight className="w-5 h-5" />
+                  </span>
+                </button>
+              )}
+
+              <div className="rounded-3xl border border-dashed border-red-ncs/40 bg-white p-8 text-sm text-black/70">
+                <p>
+                  Need to explore adjacent stacks? Return to the Tech Stacks landing to mix-and-match approaches for hybrid
+                  programmes.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TechStackDetailTemplate;

--- a/src/components/tech-stacks/WampStack.tsx
+++ b/src/components/tech-stacks/WampStack.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import TechStackDetailTemplate from './TechStackDetailTemplate';
+
+interface StackProps {
+  setCurrentPage: (page: string) => void;
+}
+
+const WampStack: React.FC<StackProps> = ({ setCurrentPage }) => {
+  return (
+    <TechStackDetailTemplate
+      name="WAMP Stack"
+      kicker="Windows-first delivery"
+      headline="Connected enterprise experiences across Windows, web, and edge"
+      description="We modernise Windows-native ecosystems by uniting PHP, .NET, and device management disciplines. Our WAMP teams harmonise enterprise authentication with beautiful, reliable UX."
+      heroImage="https://images.unsplash.com/photo-1527430253228-e93688616381?auto=format&fit=crop&w=1600&q=80"
+      appTypes={[
+        {
+          title: 'Employee and partner portals',
+          description:
+            'Craft intranets and partner hubs tightly integrated with Azure AD, Microsoft 365, and existing ERP platforms.',
+        },
+        {
+          title: 'Field service applications',
+          description:
+            'Deliver rugged, offline-first tablet and mobile apps that sync with on-premise systems and IoT sensors.',
+        },
+        {
+          title: 'Industrial IoT command centres',
+          description:
+            'Visualise telemetry from sensors, PLCs, and devices through secure dashboards with proactive alerting.',
+        },
+        {
+          title: 'Legacy system revitalisation',
+          description:
+            'Wrap existing Windows and PHP solutions with APIs, modern UI layers, and automated deployment pipelines.',
+        },
+      ]}
+      capabilities={[
+        'Windows Server, IIS, and Azure hybrid infrastructure expertise',
+        'Progressive web app patterns optimised for Edge and desktop',
+        'Secure single sign-on, MFA, and conditional access design',
+        'Device management integrations with Intune and Microsoft Defender',
+      ]}
+      accelerators={[
+        'Governed component libraries aligned to Fluent Design',
+        'Zero-trust adoption roadmaps and security tabletop exercises',
+        'IoT gateway templates bridging OPC-UA, MQTT, and REST',
+        'Lifecycle automation for packaging, updates, and monitoring',
+      ]}
+      setCurrentPage={setCurrentPage}
+      cta={{ label: 'Plan a WAMP modernisation', target: 'quote' }}
+    />
+  );
+};
+
+export default WampStack;


### PR DESCRIPTION
## Summary
- add a Tech Stacks landing page with rich stack overviews and imagery
- introduce reusable stack detail template and individual LEAN, MEAN, LAMP, and WAMP views
- wire header/footer navigation and Services CTAs into the new stack experiences

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2ae9487ac8331b800ee65adea5ad0